### PR TITLE
Weathersync integration minor patch

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -101,6 +101,11 @@ end
 RegisterNetEvent("vorpcharacter:selectCharacter")
 AddEventHandler("vorpcharacter:selectCharacter", function(myCharacters, mc)
 	local param = Config.selectedCharacter
+	local weather = Config.charselWeather
+	local permSnow = Config.charselgroundSnow
+	local hour = Config.timeHour
+	local freeze = Config.timeFreeze
+	
 	if #myCharacters < 1 then
 		return TriggerEvent("vorpcharacter:startCharacterCreator") -- id no chars then send back to creator
 	end
@@ -108,8 +113,10 @@ AddEventHandler("vorpcharacter:selectCharacter", function(myCharacters, mc)
 	MaxCharacters = mc
 	DoScreenFadeOut(1000)
 	Wait(1000)
-	exports.weathersync:setSyncEnabled(false) -- disabled weather sync
-	NetworkClockTimeOverride_2(10, 0, 0, 0, true, false)
+	--exports.weathersync:setSyncEnabled(false) -- redundant?
+	exports.weathersync:setMyWeather(weather, 10, permSnow) -- Disable weather and time sync and set a weather for this client.
+	exports.weathersync:setMyTime(hour, 0, 0, 10, freeze)
+	--NetworkClockTimeOverride_2(10, 0, 0, 0, true, false)
 	isInCharacterSelector = true
 	RegisterPrompts()
 	Controller()

--- a/client/client.lua
+++ b/client/client.lua
@@ -101,6 +101,7 @@ end
 RegisterNetEvent("vorpcharacter:selectCharacter")
 AddEventHandler("vorpcharacter:selectCharacter", function(myCharacters, mc)
 	local param = Config.selectedCharacter
+	local customWeather = Config.toggleWeatherSync
 	local weather = Config.charselWeather
 	local permSnow = Config.charselgroundSnow
 	local hour = Config.timeHour
@@ -113,10 +114,12 @@ AddEventHandler("vorpcharacter:selectCharacter", function(myCharacters, mc)
 	MaxCharacters = mc
 	DoScreenFadeOut(1000)
 	Wait(1000)
-	--exports.weathersync:setSyncEnabled(false) -- redundant?
-	exports.weathersync:setMyWeather(weather, 10, permSnow) -- Disable weather and time sync and set a weather for this client.
-	exports.weathersync:setMyTime(hour, 0, 0, 10, freeze)
-	--NetworkClockTimeOverride_2(10, 0, 0, 0, true, false)
+	
+	if customWeather then
+		exports.weathersync:setMyWeather(weather, 10, permSnow) -- Disable weather and time sync and set a weather for this client.
+		exports.weathersync:setMyTime(hour, 0, 0, 10, freeze) 
+	end
+
 	isInCharacterSelector = true
 	RegisterPrompts()
 	Controller()

--- a/config.lua
+++ b/config.lua
@@ -17,6 +17,13 @@ Config.UseSPclothing = false -- if this is true you can use SP mode clothing , i
 -- disable or allow players delete their characters
 Config.AllowPlayerDeleteCharacter = true
 
+-- Select the weather you would like to be used on the Character Selection Screen
+Config.charselWeather = 'sunny' -- See weathersync config file for a list of available weather types
+Config.charselgroundSnow = false -- Toggle whether snow should cover the ground permanently
+
+Config.timeHour = 10
+Config.timeFreeze = true
+
 Config.selectedCharacter = {
     coords = vector3(-3753.83, -2608.41, -13.99), -- where player will spawn  needs to be close to the char select
     cameraParams = {

--- a/config.lua
+++ b/config.lua
@@ -17,14 +17,14 @@ Config.UseSPclothing = false -- if this is true you can use SP mode clothing , i
 -- disable or allow players delete their characters
 Config.AllowPlayerDeleteCharacter = true
 
--- Toggle Weathersync Integration options below on/off
+-- Toggle on/off weathersync integration for the character selection options below
 Config.toggleWeatherSync = true
 
 -- Select the weather you would like to be used on the Character Selection Screen
 Config.charselWeather = 'sunny' -- See weathersync config file for a list of available weather types
 Config.charselgroundSnow = false -- Toggle whether snow should cover the ground permanently
 
--- Set the time of day to have your Character Select set to
+-- Set the time of day to have your Character Selection screen set to
 Config.timeHour = 10 -- 0 to 23 | 0 is Midnight
 Config.timeFreeze = true -- false will allow passage of time
 

--- a/config.lua
+++ b/config.lua
@@ -17,11 +17,13 @@ Config.UseSPclothing = false -- if this is true you can use SP mode clothing , i
 -- disable or allow players delete their characters
 Config.AllowPlayerDeleteCharacter = true
 
+-- Toggle Weathersync Integration options below
+Config.toggleWeatherSync = true
 -- Select the weather you would like to be used on the Character Selection Screen
 Config.charselWeather = 'sunny' -- See weathersync config file for a list of available weather types
 Config.charselgroundSnow = false -- Toggle whether snow should cover the ground permanently
-
-Config.timeHour = 10
+-- Set the time of day to have your Character Select set to
+Config.timeHour = 10 -- 0 to 23 | 0 is Midnight
 Config.timeFreeze = true
 
 Config.selectedCharacter = {

--- a/config.lua
+++ b/config.lua
@@ -24,7 +24,7 @@ Config.charselWeather = 'sunny' -- See weathersync config file for a list of ava
 Config.charselgroundSnow = false -- Toggle whether snow should cover the ground permanently
 -- Set the time of day to have your Character Select set to
 Config.timeHour = 10 -- 0 to 23 | 0 is Midnight
-Config.timeFreeze = true
+Config.timeFreeze = true -- false will allow passage of time
 
 Config.selectedCharacter = {
     coords = vector3(-3753.83, -2608.41, -13.99), -- where player will spawn  needs to be close to the char select

--- a/config.lua
+++ b/config.lua
@@ -17,11 +17,13 @@ Config.UseSPclothing = false -- if this is true you can use SP mode clothing , i
 -- disable or allow players delete their characters
 Config.AllowPlayerDeleteCharacter = true
 
--- Toggle Weathersync Integration options below
+-- Toggle Weathersync Integration options below on/off
 Config.toggleWeatherSync = true
+
 -- Select the weather you would like to be used on the Character Selection Screen
 Config.charselWeather = 'sunny' -- See weathersync config file for a list of available weather types
 Config.charselgroundSnow = false -- Toggle whether snow should cover the ground permanently
+
 -- Set the time of day to have your Character Select set to
 Config.timeHour = 10 -- 0 to 23 | 0 is Midnight
 Config.timeFreeze = true -- false will allow passage of time


### PR DESCRIPTION
Adds additional granular control over weathersync for the character selection screen

- Modifies weathersync integration with Character Selection screen
  - Adds config option to toggle entire feature on/off, re-enabling normal weather/time
  - Adds config option to enable/disable permanent snow on ground
  - Adds config option to set specific hour that is used
  - Adds config option to toggle time being frozen 

Thank you for your time ♥
-Hailey