### PR TITLE
fix: menu makeup now correctly switching to the correct previous menu when going back

### DIFF
--- a/client/menu.lua
+++ b/client/menu.lua
@@ -1575,7 +1575,7 @@ function OpenMakeupMenu(table)
             subtext = T.MenuMakeup.subtitle,
             align = Config.Align,
             elements = elements,
-            lastmenu = "OpenFaceMenu"
+            lastmenu = "OpenAppearanceMenu"
         },
 
         function(data, menu)


### PR DESCRIPTION
While in the character creation process, entering the menu `Appearances - Makeup` and returning to the previous menu, you got into `Appearances - Face Features` instead of only `Appearance`