### PR TITLE
translations  and show the right Currency for confirm purchase description in second chance 

### DIFF
--- a/client/menu.lua
+++ b/client/menu.lua
@@ -176,9 +176,19 @@ function GetDescriptionLayout(value, price)
     local desc = imgPath:format(value.img) ..
         "<br><br>" .. value.desc .. "<br><br><br><br>" .. Divider ..
         "<br><span style='font-family:crock; float:left; font-size: 22px;'>" ..
-        T.PayToShop.Total .. " </span><span style='font-family:crock;float:right; font-size: 22px;'>$" ..
-        (price or GetCurrentAmmountToPay()) .. "</span><br>" .. Divider
-    return desc
+        T.PayToShop.Total .. " </span><span style='font-family:crock;float:right; font-size: 22px;'>"
+
+    if  ShopType == "secondchance" then
+        if ConfigShops.SecondChanceCurrency == 0 then
+            desc = desc .. T.PayToShop.Currency
+        elseif ConfigShops.SecondChanceCurrency == 1 then
+            desc = desc .. T.Other.Gold
+        elseif ConfigShops.SecondChanceCurrency == 2 then
+            desc = desc .. T.PayToShop.Tokens
+        end
+        desc = desc .. (price or GetCurrentAmmountToPay()) .. "</span><br>" .. Divider
+        return desc
+    end
 end
 
 function OpenCharCreationMenu(clothingtable, value)

--- a/shared/translation.lua
+++ b/shared/translation.lua
@@ -178,6 +178,9 @@ Translation.Langs = {
             DontMoney = "You don't have enough of %s Ammount is: $%s",
             Youpaid = "You paid $%s",
             Total = 'Total:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Appearance",
@@ -480,6 +483,9 @@ Translation.Langs = {
             DontMoney = "Non hai  %s L'ammontare è: $%s",
             Youpaid = "Hai pagato $%s",
             Total = 'Totale:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Aspetto",
@@ -788,6 +794,9 @@ Translation.Langs = {
             DontMoney = "Você não tem %s suficiente montante é: $%s",
             Youpaid = "Você pagou $%s",
             Total = 'Total:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Aparência",
@@ -1071,6 +1080,9 @@ Translation.Langs = {
             DontMoney = "Você não tem  %s suficiente montante é: $%s",
             Youpaid = "Você pagou $%s",
             Total = 'Total:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Aparência",
@@ -1372,6 +1384,9 @@ Translation.Langs = {
             DontMoney = "Vous n'avez pas assez d'argent %s le montant est : $%s",
             Youpaid = "Vous avez payé $%s",
             Total = 'Total :',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Apparence",
@@ -1687,6 +1702,9 @@ Translation.Langs = {
             DontMoney = "Du hast nicht genug Geld %s der Betrag ist : $%s",
             Youpaid = "Du hast $%s bezahlt",
             Total = 'Gesamt:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
+            
         },
         MenuAppearance = {
             title = "Aussehen",
@@ -1984,6 +2002,8 @@ Translation.Langs = {
             DontMoney = "No tienes suficiente  %s el monto es : $%s",
             Youpaid = "Pagaste $%s",
             Total = 'Total:',
+            Tokens = 'Tokens: ',
+            Currency = '$',
         },
         MenuAppearance = {
             title = "Apariencia",


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

Adding translations for the confirm purchase in Second chance and showing the right Currency  type in the second chance menu for confirm purchase description

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
  - will add translations for the confirm purchase in Second chance 

 -  will show the right Currency  type in the second chance menu for confirm purchase description

### Explain the necessity of these changes and how they will impact the framework or its users.

makes for easier config for translations of this menu element

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x ] Tested with latest vorp scripts
- [x ] Tested with latest artifacts

## Notes if any
explanation field

![image](https://github.com/VORPCORE/vorp_character-lua/assets/26008458/31b1910f-be19-4c0a-9eb8-9695b8670e0a)
![image](https://github.com/VORPCORE/vorp_character-lua/assets/26008458/17363d75-9e0f-4d4f-8509-b4689c5fed06)
![image](https://github.com/VORPCORE/vorp_character-lua/assets/26008458/5ad83c1e-0f3b-4222-9fce-7d48571d4045)



