### PR TITLE
Fix fatness, ped in RemoveMetaTags and store blip colors

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -137,8 +137,8 @@ end)
 local function LoadFaceFeatures(ped, skin)
 	for key, value in pairs(Config.FaceFeatures) do
 		for label, v in pairs(value) do
-			if skin[v.comp] and v.hash ~= 0 then
-				SetCharExpression(ped, v.hash, skin[v.comp])
+			if value[v.comp] and v.hash ~= 0 then
+				SetCharExpression(ped, v.hash, value[v.comp])
 				Citizen.InvokeNative(0xAAB86462966168CE, ped, 1)
 			end
 		end

--- a/client/clothingstore.lua
+++ b/client/clothingstore.lua
@@ -19,6 +19,9 @@ function CreateBlips()
         if value.Blip.Enable then
             local blip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, value.Prompt.Position.x,
                 value.Prompt.Position.y, value.Prompt.Position.z)
+            if value.Blip.Color then
+                Citizen.InvokeNative(0x662D364ABF16DE2F, blip, joaat(value.Blip.Color)) -- BlipAddModifier
+            end
             SetBlipSprite(blip, value.Blip.Sprite, true)
             Citizen.InvokeNative(0x9CB1A1623062F402, blip, value.Blip.Name)
             ConfigShops.Locations[index].Blip.Entity = blip

--- a/client/creator_functions.lua
+++ b/client/creator_functions.lua
@@ -149,8 +149,8 @@ function RefreshMetaPedShopItems()
     Citizen.InvokeNative(0x59BD177A1A48600A, PlayerPedId(), 1)
 end
 
-function RemoveTagFromMetaPed(hash)
-    Citizen.InvokeNative(0xD710A5007C2AC539, PlayerPedId(), hash, 0)
+function RemoveTagFromMetaPed(hash, ped)
+    Citizen.InvokeNative(0xD710A5007C2AC539, ped or PlayerPedId(), hash, 0)
 end
 
 function UpdatePedVariation(ped)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -2,8 +2,8 @@
 ---@param ped number ped id
 function RemoveMetaTags(ped)
     for _, tag in pairs(Config.HashList) do
-        RemoveTagFromMetaPed(tag)
-        UpdatePedVariation()
+        RemoveTagFromMetaPed(tag, ped)
+        UpdatePedVariation(ped)
     end
 end
 

--- a/config_shops.lua
+++ b/config_shops.lua
@@ -13,6 +13,8 @@ ConfigShops.SecondChanceCurrency = 0     -- 0 is cash 1 is gold 2 is tokens curr
 -- face
 -- secondchance -- this enables all
 
+-- Blip Colors: https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/blip_modifiers
+
 ConfigShops.Locations = {
     {                                                   -- valentine
         Prompt = {
@@ -28,6 +30,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(-329.43, 775.29, 121.63, 278.17),
@@ -59,6 +62,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(-767.98, -1294.88, 43.83, 263.09),
@@ -90,6 +94,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Rhodes Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(1324.24, -1287.88, 77.07, 164.22),
@@ -121,6 +126,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Saint Denis Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(2556.66, -1159.76, 53.75, 191.14),
@@ -152,6 +158,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Strawberry Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(-1794.4, -395.25, 160.34, 326.06),
@@ -183,6 +190,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Tumbleweed Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(-5480.05, -2932.88, -0.32, 229.49),
@@ -214,6 +222,7 @@ ConfigShops.Locations = {
             Enable = true,
             Sprite = 1195729388,
             Name = "Armadillo Clothing Store",
+            -- Color = 'BLIP_MODIFIER_MP_COLOR_23',
         },
         EditCharacter = { -- where the player will be teleported to edit character
             Position = vector4(-3688.98, -2630.14, -13.35, 6.45),


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
explanation field

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
- Fixed characters not applying fatness due to calling `SetCharExpression` incorrectly in the `LoadFaceFeatures` function
- Added the `Color` option in the blips, to choose the color of the blip for each store.
- Fixed calling RemoveMetaTags using a ped, then RemoveTagFromMetaPed and UpdatePedVariation not being called with that ped.

### Explain the necessity of these changes and how they will impact the framework or its users.
explanation field

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x ] Tested with latest vorp scripts
- [x ] Tested with latest artifacts

## Notes if any
explanation field
