### PR TITLE
fix: stop age from allowing text

### DIFF
--- a/client/menu.lua
+++ b/client/menu.lua
@@ -351,7 +351,7 @@ function OpenCharCreationMenu(clothingtable, value)
                     style = "block",
                     attributes = {
                         inputHeader = T.Inputs.inputHeadertype,
-                        type = "text",
+                        type = "number",
                         -- dont allow negative numbers
                         min = "0",
                         title = T.Inputs.title,


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

if someone types letters in Age and not numbers it will error out saving to the DB and not save the character 

![image](https://github.com/VORPCORE/vorp_character-lua/assets/26008458/cc8f590a-cdf4-4f47-8eae-9d20ea22a06b)


### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

changing input type  to number from text will stop being able to add letters and erroring out on the DB 

### Explain the necessity of these changes and how they will impact the framework or its users.
explanation field

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
explanation field
