### PR TITLE
Added option to enable/disable the initial RDO intro scene

### DIFF
--- a/client/createCharacter.lua
+++ b/client/createCharacter.lua
@@ -47,7 +47,7 @@ local function Setup()
 	local animscene = -1 
 	local peds = {}
 
-	if(Config.UseInitialAnimScene) then
+	if Config.UseInitialAnimScene then
 		animscene, peds = SetupAnimscene()
 		LoadAnimScene(animscene)
 		repeat Wait(0) until Citizen.InvokeNative(0x477122B8D05E7968, animscene)
@@ -60,7 +60,7 @@ local function Setup()
 	DoScreenFadeIn(3000)
 	repeat Wait(0) until IsScreenFadedIn()
 
-	if (Config.UseInitialAnimScene) then
+	if Config.UseInitialAnimScene then
 		repeat Wait(0) until Citizen.InvokeNative(0xCBFC7725DE6CE2E0, animscene)
 	end
 
@@ -103,7 +103,7 @@ local function Setup()
 
 	
 	
-	if (Config.UseInitialAnimScene) then
+	if Config.UseInitialAnimScene then
 
 		Citizen.InvokeNative(0xAB5E7CAB074D6B84, animscene, ("Pl_Start_to_Edit_%s"):format(gender))
 		while not (Citizen.InvokeNative(0x3FBC3F51BF12DFBF, animscene, Citizen.ResultAsFloat()) > 0.2) do
@@ -126,7 +126,7 @@ local function Setup()
 	N_0x11f32bb61b756732(cam, 1.0)
 
 	
-	if (Config.UseInitialAnimScene) then
+	if Config.UseInitialAnimScene then
 		while not (N_0xd8254cb2c586412b(animscene) == 1) do
 			Citizen.Wait(0)
 		end

--- a/client/createCharacter.lua
+++ b/client/createCharacter.lua
@@ -44,17 +44,25 @@ local function Setup()
 	repeat Wait(0) until HasCollisionLoadedAroundEntity(PlayerPedId())
 
 	local cam = SetupCameraCharacterCreationSelect()
-	local animscene, peds = SetupAnimscene()
+	local animscene = -1 
+	local peds = {}
 
-	LoadAnimScene(animscene)
-	repeat Wait(0) until Citizen.InvokeNative(0x477122B8D05E7968, animscene)
+	if(Config.UseInitialAnimScene) then
+		animscene, peds = SetupAnimscene()
+		LoadAnimScene(animscene)
+		repeat Wait(0) until Citizen.InvokeNative(0x477122B8D05E7968, animscene)
 
-	StartAnimScene(animscene)
+		StartAnimScene(animscene)
+	else
+		peds = SelectionPeds()
+	end
 
 	DoScreenFadeIn(3000)
 	repeat Wait(0) until IsScreenFadedIn()
 
-	repeat Wait(0) until Citizen.InvokeNative(0xCBFC7725DE6CE2E0, animscene)
+	if (Config.UseInitialAnimScene) then
+		repeat Wait(0) until Citizen.InvokeNative(0xCBFC7725DE6CE2E0, animscene)
+	end
 
 	SetCamParams(cam, vec3(-562.15, -3776.22, 239.11), vec3(-4.71, 0.0, -93.14), 45.0, 0, 1, 1, 2, 1, 1)
 
@@ -92,18 +100,38 @@ local function Setup()
 	UiFeedClearChannel(3, true, false)
 	local ped = peds[char + 1]
 	local gender = IsPedMale(ped) and "Male" or "Female"
-	Citizen.InvokeNative(0xAB5E7CAB074D6B84, animscene, ("Pl_Start_to_Edit_%s"):format(gender))
-	while not (Citizen.InvokeNative(0x3FBC3F51BF12DFBF, animscene, Citizen.ResultAsFloat()) > 0.2) do
-		Citizen.Wait(0)
+
+	
+	
+	if (Config.UseInitialAnimScene) then
+
+		Citizen.InvokeNative(0xAB5E7CAB074D6B84, animscene, ("Pl_Start_to_Edit_%s"):format(gender))
+		while not (Citizen.InvokeNative(0x3FBC3F51BF12DFBF, animscene, Citizen.ResultAsFloat()) > 0.2) do
+			Citizen.Wait(0)
+		end
+	else 
+		ClearPedTasksImmediately(ped)
+		TaskGoStraightToCoord(ped, -558.79, -3780.17, 238.59, 1.0, -1, 183.2, 0)
+		-- set camera to follow the ped for 1 second with a loop that will break after 1 second
+		while true do
+			PointCamAtEntity(cam, ped, 0.0, 0.0, 0.0, true)
+			Wait(0)
+			if GetScriptTaskStatus(ped, 0x7D8F4411, true) == 8 then
+				break
+			end
+		end
 	end
 
 	SetCamParams(cam, vec3(-561.82, -3780.97, 239.08), vec3(-4.21, 0.0, -87.88), 30.0, 0, 1, 1, 2, 1, 1)
 	N_0x11f32bb61b756732(cam, 1.0)
 
-	while not (N_0xd8254cb2c586412b(animscene) == 1) do
-		Citizen.Wait(0)
+	
+	if (Config.UseInitialAnimScene) then
+		while not (N_0xd8254cb2c586412b(animscene) == 1) do
+			Citizen.Wait(0)
+		end
+		Citizen.InvokeNative(0x84EEDB2C6E650000, animscene) -- delete animscene
 	end
-	Citizen.InvokeNative(0x84EEDB2C6E650000, animscene) -- delete animscene
 	RegisterGenderPrompt()
 
 	if gender ~= "Male" then

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -264,6 +264,27 @@ function SetupAnimscene()
     return animscene, { Male_MP, Female_MP, Sheriff, Deputy }
 end
 
+function SelectionPeds()
+    local fModel = "MP_FEMALE"
+    local mModel = "MP_MALE"
+
+    LoadPlayer(fModel)
+    Female_MP = CreatePed(joaat(fModel), -558.43, -3776.65, 237.7, 93.2, false, true, true, true)
+    TaskStandStill(Female_MP, -1)
+    SetEntityInvincible(Female_MP, true)
+    DefaultPedSetup(Female_MP, false)
+    SetModelAsNoLongerNeeded(fModel)
+
+    LoadPlayer(mModel)
+    Male_MP = CreatePed(joaat(mModel), -558.52, -3775.6, 237.7, 93.2, false, true, true, true)
+    TaskStandStill(Male_MP, -1)
+    SetEntityInvincible(Male_MP, true)
+    DefaultPedSetup(Male_MP, true)
+    SetModelAsNoLongerNeeded(mModel)
+
+    return { Male_MP, Female_MP }
+end
+
 function SetupScenes(string)
     local animscene = CreateAnimScene("script@mp@character_creator@transitions", 0.25, string, false, true)
     SetAnimSceneEntity(animscene, GetGender() .. "_MP", PlayerPedId(), 0)

--- a/config.lua
+++ b/config.lua
@@ -13,6 +13,9 @@ Config.AllowPlayerDeleteCharacter = true
 
 Config.ReloadCharCommand = "rc"
 
+-- Option to enable/disable the initial RDO intro
+Config.UseInitialAnimScene = true
+
 -- after creating character player will spawn here
 Config.SpawnCoords = {
     { -- BLW


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Some people may not like the initial RDO intro scene, or it may not be appropriate to their roleplay server ambientation.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
The changes proposed are: having the possibility to choose using the RDO intro or a simplified version without the two NPC talking and the cutscene.

### Explain the necessity of these changes and how they will impact the framework or its users.
The change is necessary for servers which have a particular ambientation that cannot go along with the RDO intro, the change will not impact people that like the RDO intro as the default settings is still to leave it on.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with the latest vorp_core and vorp_character
- [x] Tested with the RDO intro on
- [x] Tested with the RDO intro off
