### PR TITLE
fix(spawn): wait for character session before init

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -119,10 +119,29 @@ local function iniSpawn()
 	return selectedSpawn.position, selectedSpawn.heading
 end
 
+local function WaitForCharacterSession(source, timeoutMs)
+	local timeout = timeoutMs or 15000
+	local startTime = GetGameTimer()
+
+	while GetGameTimer() - startTime < timeout do
+		local state = Player(source).state
+		if state and state.IsInSession and state.Character and state.Character.CharId then
+			return true
+		end
+		Wait(50)
+	end
+
+	return false
+end
+
 RegisterServerEvent("vorpcharacter:saveCharacter", function(data)
 	local _source = source
 	Core.getUser(_source).addCharacter(data)
-	Wait(600)
+
+	if not WaitForCharacterSession(_source) then
+		print(("vorp_character: timed out waiting for character session initialization for source %s"):format(_source))
+	end
+
 	local iniPos, iniHead = iniSpawn()
 	TriggerClientEvent("vorp:initCharacter", _source, iniPos, iniHead, false)
 	SetTimeout(3000, function()


### PR DESCRIPTION
## Type of Change

* [x] Bug fix (non-breaking change that resolves an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (a fix or feature that may affect existing functionality)
* [ ] Documentation update required

## Description

This PR fixes a race condition during new character creation.

Previously, `vorp_character` used a fixed delay of `600ms` after `addCharacter(data)`
before triggering `vorp:initCharacter`. In some cases, this delay was insufficient,
causing initialization to occur before `vorp_core` had fully attached the character session.

This could result in inconsistent first spawn behavior, such as players spawning with incomplete health.

* [x] Tested with latest VORP scripts
* [x] Tested with latest artifacts

## Additional Notes

This issue was likely caused by relying on a fixed delay instead of ensuring the character session was fully ready, leading to inconsistent spawn states.
