### PR TITLE
feat: use clone peds to display overlay in char selection

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -167,6 +167,59 @@ local function LoadFaceFeatures(ped, skin)
 	end
 end
 
+local function ApplyPedOverlays(ped, skin)
+	canContinue = false
+
+	FaceOverlay("beardstabble", skin.beardstabble_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.beardstabble_color_primary, 0, 0, 1, skin.beardstabble_opacity)
+	FaceOverlay("hair", skin.hair_visibility, skin.hair_tx_id, 1, 0, 0, 1.0, 0, 1, skin.hair_color_primary, 0, 0, 1, skin.hair_opacity)
+	FaceOverlay("scars", skin.scars_visibility, skin.scars_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.scars_opacity)
+	FaceOverlay("spots", skin.spots_visibility, skin.spots_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.spots_opacity)
+	FaceOverlay("disc", skin.disc_visibility, skin.disc_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.disc_opacity)
+	FaceOverlay("complex", skin.complex_visibility, skin.complex_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.complex_opacity)
+	FaceOverlay("acne", skin.acne_visibility, skin.acne_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.acne_opacity)
+	FaceOverlay("ageing", skin.ageing_visibility, skin.ageing_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.ageing_opacity)
+	FaceOverlay("freckles", skin.freckles_visibility, skin.freckles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.freckles_opacity)
+	FaceOverlay("moles", skin.moles_visibility, skin.moles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.moles_opacity)
+	FaceOverlay("shadows", skin.shadows_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.shadows_palette_color_primary, skin.shadows_palette_color_secondary, skin.shadows_palette_color_tertiary, skin.shadows_palette_id, skin.shadows_opacity)
+	FaceOverlay("eyebrows", skin.eyebrows_visibility, skin.eyebrows_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyebrows_color, 0, 0, 1, skin.eyebrows_opacity)
+	FaceOverlay("eyeliners", skin.eyeliner_visibility, skin.eyeliner_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyeliner_color_primary, 0, 0, skin.eyeliner_palette_id, skin.eyeliner_opacity)
+	FaceOverlay("blush", skin.blush_visibility, skin.blush_tx_id, 1, 0, 0, 1.0, 0, 1, skin.blush_palette_color_primary, 0, 0, 1, skin.blush_opacity)
+	FaceOverlay("lipsticks", skin.lipsticks_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.lipsticks_palette_color_primary, skin.lipsticks_palette_color_secondary, skin.lipsticks_palette_color_tertiary, skin.lipsticks_palette_id, skin.lipsticks_opacity)
+
+	local gender = skin.sex == "mp_male" and "Male" or "Female"
+	local current_texture_settings = Config.texture_types[gender]
+
+	local albedo = skin.albedo
+	if not albedo or albedo == 0 then
+		albedo = current_texture_settings.albedo
+	end
+
+	if textureId ~= -1 then
+		Citizen.InvokeNative(0xB63B9178D0F58D82, textureId)
+		Citizen.InvokeNative(0x6BEFAA907B076859, textureId)
+	end
+
+	textureId = Citizen.InvokeNative(0xC5E7204F322E49EB, albedo, current_texture_settings.normal, current_texture_settings.material)
+	for k, v in ipairs(Config.overlay_all_layers) do
+		if v.visibility ~= 0 then
+			local overlay_id = Citizen.InvokeNative(0x86BB5FF45F193A02, textureId, v.tx_id, v.tx_normal, v.tx_material, v.tx_color_type, v.tx_opacity, v.tx_unk)
+			if v.tx_color_type == 0 then
+				Citizen.InvokeNative(0x1ED8588524AC9BE1, textureId, overlay_id, v.palette)
+				Citizen.InvokeNative(0x2DF59FFE6FFD6044, textureId, overlay_id, v.palette_color_primary, v.palette_color_secondary, v.palette_color_tertiary)
+			end
+			Citizen.InvokeNative(0x3329AAE2882FC8E4, textureId, overlay_id, v.var)
+			Citizen.InvokeNative(0x6C76BC24F8BB709A, textureId, overlay_id, v.opacity)
+		end
+	end
+
+	repeat Wait(0) until Citizen.InvokeNative(0x31DC8D3F216D8509, textureId)
+
+	Citizen.InvokeNative(0x0B46E25761519058, ped, joaat("heads"), textureId)
+	Citizen.InvokeNative(0x92DAABA2C1C10B0E, textureId)
+	IsPedReadyToRender(ped)
+	UpdatePedVariation(ped)
+end
+
 local function ApplyAllComponents(category, value, ped, set)
 	if value.comp == -1 then
 		return
@@ -290,6 +343,13 @@ end
 
 local function LoadCharacterSelect(ped, skin, components)
 	local gender = skin.sex == "mp_male" and "M" or "F"
+
+	if skin.sex ~= "mp_male" then
+		EquipMetaPedOutfitPreset(ped, 7)
+	else
+		EquipMetaPedOutfitPreset(ped, 4)
+	end
+
 	LoadAll(gender, ped, skin, components, false)
 	SetAttributeCoreValue(ped, 1, 100)
 	SetAttributeCoreValue(ped, 0, 100)
@@ -369,16 +429,27 @@ function StartSwapCharacters()
 			return error("your config spawn locations doesnt have enough spawn locations you need to add: " .. #myChars .. "Spawn locations")
 		end
 
-		data.PedHandler = CreatePed(joaat(value.skin.sex), data.spawn.x, data.spawn.y, data.spawn.z, data.spawn.w, false, false, false, false)
+		local modelHash = joaat(value.skin.sex)
+		SetPlayerModel(PlayerId(), modelHash, false)
+		local playerPed = PlayerPedId()
 
-		local start = GetGameTimer()
-		repeat Wait(0) until DoesEntityExist(data.PedHandler) or GetGameTimer() - start > 5000
-		if GetGameTimer() - start > 5000 then
-			print("Failed to create peds")
-			break
+		LoadCharacterSelect(playerPed, value.skin, value.components)
+		ApplyPedOverlays(playerPed, value.skin)
+		Wait(100)
+
+		data.PedHandler = ClonePed(playerPed, false, false, false, false)
+
+		if not data.PedHandler or not DoesEntityExist(data.PedHandler) then
+			data.PedHandler = CreatePed(modelHash, data.spawn.x, data.spawn.y, data.spawn.z, data.spawn.w, false, false, false, false)
+			LoadCharacterSelect(data.PedHandler, value.skin, value.components)
+		else
+			SetEntityCoords(data.PedHandler, data.spawn.x, data.spawn.y, data.spawn.z, false, false, false, false)
+			SetEntityHeading(data.PedHandler, data.spawn.w)
 		end
 
-		LoadCharacterSelect(data.PedHandler, value.skin, value.components)
+		SetEntityVisible(playerPed, false)
+		FreezeEntityPosition(playerPed, true)
+
 		data.Cam = CreateCamWithParams("DEFAULT_SCRIPTED_CAMERA", data.camera.x, data.camera.y, data.camera.z, data.camera.rotx, data.camera.roty, data.camera.rotz, data.camera.fov, false, 2)
 		SetEntityInvincible(data.PedHandler, true)
 		local randomScenario = math.random(1, #data.scenario[value.skin.sex])

--- a/client/client.lua
+++ b/client/client.lua
@@ -167,57 +167,22 @@ local function LoadFaceFeatures(ped, skin)
 	end
 end
 
-local function ApplyPedOverlays(ped, skin)
-	canContinue = false
-
-	FaceOverlay("beardstabble", skin.beardstabble_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.beardstabble_color_primary, 0, 0, 1, skin.beardstabble_opacity)
-	FaceOverlay("hair", skin.hair_visibility, skin.hair_tx_id, 1, 0, 0, 1.0, 0, 1, skin.hair_color_primary, 0, 0, 1, skin.hair_opacity)
-	FaceOverlay("scars", skin.scars_visibility, skin.scars_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.scars_opacity)
-	FaceOverlay("spots", skin.spots_visibility, skin.spots_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.spots_opacity)
-	FaceOverlay("disc", skin.disc_visibility, skin.disc_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.disc_opacity)
-	FaceOverlay("complex", skin.complex_visibility, skin.complex_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.complex_opacity)
-	FaceOverlay("acne", skin.acne_visibility, skin.acne_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.acne_opacity)
-	FaceOverlay("ageing", skin.ageing_visibility, skin.ageing_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.ageing_opacity)
-	FaceOverlay("freckles", skin.freckles_visibility, skin.freckles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.freckles_opacity)
-	FaceOverlay("moles", skin.moles_visibility, skin.moles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.moles_opacity)
-	FaceOverlay("shadows", skin.shadows_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.shadows_palette_color_primary, skin.shadows_palette_color_secondary, skin.shadows_palette_color_tertiary, skin.shadows_palette_id, skin.shadows_opacity)
-	FaceOverlay("eyebrows", skin.eyebrows_visibility, skin.eyebrows_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyebrows_color, 0, 0, 1, skin.eyebrows_opacity)
-	FaceOverlay("eyeliners", skin.eyeliner_visibility, skin.eyeliner_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyeliner_color_primary, 0, 0, skin.eyeliner_palette_id, skin.eyeliner_opacity)
-	FaceOverlay("blush", skin.blush_visibility, skin.blush_tx_id, 1, 0, 0, 1.0, 0, 1, skin.blush_palette_color_primary, 0, 0, 1, skin.blush_opacity)
-	FaceOverlay("lipsticks", skin.lipsticks_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.lipsticks_palette_color_primary, skin.lipsticks_palette_color_secondary, skin.lipsticks_palette_color_tertiary, skin.lipsticks_palette_id, skin.lipsticks_opacity)
-
-	local gender = skin.sex == "mp_male" and "Male" or "Female"
-	local current_texture_settings = Config.texture_types[gender]
-
-	local albedo = skin.albedo
-	if not albedo or albedo == 0 then
-		albedo = current_texture_settings.albedo
+local function ApplyFaceOverlays(skin)
+	for _, n in ipairs({"scars","spots","disc","complex","acne","ageing","freckles","moles"}) do
+		FaceOverlay(n, skin[n.."_visibility"], skin[n.."_tx_id"], 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin[n.."_opacity"])
 	end
-
-	if textureId ~= -1 then
-		Citizen.InvokeNative(0xB63B9178D0F58D82, textureId)
-		Citizen.InvokeNative(0x6BEFAA907B076859, textureId)
+	local V = function(k) return type(k)=="number" and k or skin[k] end
+	for _, o in ipairs({
+		{"beardstabble","beardstabble",1,"beardstabble_color_primary",0,0,1},
+		{"hair","hair","hair_tx_id","hair_color_primary",0,0,1},
+		{"shadows","shadows",1,"shadows_palette_color_primary","shadows_palette_color_secondary","shadows_palette_color_tertiary","shadows_palette_id"},
+		{"eyebrows","eyebrows","eyebrows_tx_id","eyebrows_color",0,0,1},
+		{"eyeliners","eyeliner","eyeliner_tx_id","eyeliner_color_primary",0,0,"eyeliner_palette_id"},
+		{"blush","blush","blush_tx_id","blush_palette_color_primary",0,0,1},
+		{"lipsticks","lipsticks",1,"lipsticks_palette_color_primary","lipsticks_palette_color_secondary","lipsticks_palette_color_tertiary","lipsticks_palette_id"},
+	}) do
+		FaceOverlay(o[1], skin[o[2].."_visibility"], V(o[3]), 1, 0, 0, 1.0, 0, 1, V(o[4]), V(o[5]), V(o[6]), V(o[7]), skin[o[2].."_opacity"])
 	end
-
-	textureId = Citizen.InvokeNative(0xC5E7204F322E49EB, albedo, current_texture_settings.normal, current_texture_settings.material)
-	for k, v in ipairs(Config.overlay_all_layers) do
-		if v.visibility ~= 0 then
-			local overlay_id = Citizen.InvokeNative(0x86BB5FF45F193A02, textureId, v.tx_id, v.tx_normal, v.tx_material, v.tx_color_type, v.tx_opacity, v.tx_unk)
-			if v.tx_color_type == 0 then
-				Citizen.InvokeNative(0x1ED8588524AC9BE1, textureId, overlay_id, v.palette)
-				Citizen.InvokeNative(0x2DF59FFE6FFD6044, textureId, overlay_id, v.palette_color_primary, v.palette_color_secondary, v.palette_color_tertiary)
-			end
-			Citizen.InvokeNative(0x3329AAE2882FC8E4, textureId, overlay_id, v.var)
-			Citizen.InvokeNative(0x6C76BC24F8BB709A, textureId, overlay_id, v.opacity)
-		end
-	end
-
-	repeat Wait(0) until Citizen.InvokeNative(0x31DC8D3F216D8509, textureId)
-
-	Citizen.InvokeNative(0x0B46E25761519058, ped, joaat("heads"), textureId)
-	Citizen.InvokeNative(0x92DAABA2C1C10B0E, textureId)
-	IsPedReadyToRender(ped)
-	UpdatePedVariation(ped)
 end
 
 local function ApplyAllComponents(category, value, ped, set)
@@ -434,8 +399,12 @@ function StartSwapCharacters()
 		local playerPed = PlayerPedId()
 
 		LoadCharacterSelect(playerPed, value.skin, value.components)
-		ApplyPedOverlays(playerPed, value.skin)
-		Wait(100)
+		CachedSkin = value.skin
+		canContinue = false
+		ApplyFaceOverlays(value.skin)
+		canContinue = true
+		FaceOverlay("grime", value.skin.grime_visibility, value.skin.grime_tx_id, 0, 0, 0, 1.0, 0, 1, 0, 0, 0, 1, value.skin.grime_opacity)
+		Wait(500)
 
 		data.PedHandler = ClonePed(playerPed, false, false, false, false)
 
@@ -773,21 +742,8 @@ function LoadPlayerComponents(ped, skin, components, reload)
 	skin = LoadAll(gender, ped, skin, components, true)
 	RegisterBodyIndexs(skin)
 	ApplyRolledClothingStatus()
-	FaceOverlay("beardstabble", skin.beardstabble_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.beardstabble_color_primary, 0, 0, 1, skin.beardstabble_opacity)
-	FaceOverlay("hair", skin.hair_visibility, skin.hair_tx_id, 1, 0, 0, 1.0, 0, 1, skin.hair_color_primary, 0, 0, 1, skin.hair_opacity)
-	FaceOverlay("scars", skin.scars_visibility, skin.scars_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.scars_opacity)
-	FaceOverlay("spots", skin.spots_visibility, skin.spots_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.spots_opacity)
-	FaceOverlay("disc", skin.disc_visibility, skin.disc_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.disc_opacity)
-	FaceOverlay("complex", skin.complex_visibility, skin.complex_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.complex_opacity)
-	FaceOverlay("acne", skin.acne_visibility, skin.acne_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.acne_opacity)
-	FaceOverlay("ageing", skin.ageing_visibility, skin.ageing_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.ageing_opacity)
-	FaceOverlay("freckles", skin.freckles_visibility, skin.freckles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.freckles_opacity)
-	FaceOverlay("moles", skin.moles_visibility, skin.moles_tx_id, 0, 0, 1, 1.0, 0, 0, 0, 0, 0, 1, skin.moles_opacity)
-	FaceOverlay("shadows", skin.shadows_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.shadows_palette_color_primary, skin.shadows_palette_color_secondary, skin.shadows_palette_color_tertiary, skin.shadows_palette_id, skin.shadows_opacity)
-	FaceOverlay("eyebrows", skin.eyebrows_visibility, skin.eyebrows_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyebrows_color, 0, 0, 1, skin.eyebrows_opacity)
-	FaceOverlay("eyeliners", skin.eyeliner_visibility, skin.eyeliner_tx_id, 1, 0, 0, 1.0, 0, 1, skin.eyeliner_color_primary, 0, 0, skin.eyeliner_palette_id, skin.eyeliner_opacity)
-	FaceOverlay("blush", skin.blush_visibility, skin.blush_tx_id, 1, 0, 0, 1.0, 0, 1, skin.blush_palette_color_primary, 0, 0, 1, skin.blush_opacity)
-	FaceOverlay("lipsticks", skin.lipsticks_visibility, 1, 1, 0, 0, 1.0, 0, 1, skin.lipsticks_palette_color_primary, skin.lipsticks_palette_color_secondary, skin.lipsticks_palette_color_tertiary, skin.lipsticks_palette_id, skin.lipsticks_opacity)
+	canContinue = false
+	ApplyFaceOverlays(skin)
 	canContinue = true
 	FaceOverlay("grime", skin.grime_visibility, skin.grime_tx_id, 0, 0, 0, 1.0, 0, 1, 0, 0, 0, 1, skin.grime_opacity)
 	Wait(200)

--- a/client/client.lua
+++ b/client/client.lua
@@ -451,7 +451,10 @@ function StartSwapCharacters()
 		FreezeEntityPosition(playerPed, true)
 
 		data.Cam = CreateCamWithParams("DEFAULT_SCRIPTED_CAMERA", data.camera.x, data.camera.y, data.camera.z, data.camera.rotx, data.camera.roty, data.camera.rotz, data.camera.fov, false, 2)
+		FreezeEntityPosition(data.PedHandler, false)
 		SetEntityInvincible(data.PedHandler, true)
+		ClearPedTasks(data.PedHandler)
+		Wait(100)
 		local randomScenario = math.random(1, #data.scenario[value.skin.sex])
 		Citizen.InvokeNative(0x524B54361229154F, data.PedHandler, joaat(data.scenario[value.skin.sex][randomScenario]), -1, false, joaat(data.scenario[value.skin.sex][randomScenario]), -1.0, 0)
 		Peds[#Peds + 1] = data.PedHandler


### PR DESCRIPTION
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Character selection lobby peds did not display face overlays (eyebrows, scars, eyeliner, lipstick, freckles, etc.) - only body components were shown. This made characters look incomplete during selection.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

The RDR3 native **_APPLY_TEXTURE_ON_PED** does not apply overlay textures to peds created with **CreatePed**. It only works on **PlayerPedId()**. To work around this, we now apply overlays to the player ped first, then clone it using **ClonePed**. The cloned ped retains all overlay settings and is used as the lobby preview ped. Any other attempts to apply overlays to created peds, without cloning, will not apply the overlay settings to themselves.

### Explain the necessity of these changes and how they will impact the framework or its users.
Without this fix, players selecting a character in the lobby see a face with no overlays - no eyebrows, no scars, no makeup. This is confusing because the character looks different from how it will appear in-game. After this change, the lobby preview matches the actual character appearance. No breaking changes - the player ped remains invisible during the lobby as before.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [X] Verified overlays (eyebrows, scars, etc.) are visible on cloned lobby peds for both mp_male and mp_female characters.
- [X] Verified cloned peds are positioned correctly at lobby spawn points.
- [x] Verified camera, scenario animations, and character selection menu still function normally.
- [X] Verified fallback to CreatePed if ClonePed fails.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts

## Notes if any
Below is the result before and after the changes:
**BEFORE:**
<img width="1486" height="1439" alt="Снимок экрана 2026-04-28 234643" src="https://github.com/user-attachments/assets/ea57c233-7a33-4504-92b5-aaae7e4fe777" />
**AFTER:**
<img width="1477" height="1378" alt="Снимок экрана 2026-04-28 234307" src="https://github.com/user-attachments/assets/d4b978c9-b6c6-49bd-af0b-6650ea5f86b2" />
**In addition, after changing the appearance, it clones correctly:**
<img width="1478" height="1438" alt="Снимок экрана 2026-04-28 235453" src="https://github.com/user-attachments/assets/e0522609-0ae9-4777-8f31-b28d67e9961e" />
